### PR TITLE
remove testing on django 1.6 and 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   - "2.7"
 env:
-  - DJANGO="Django>=1.6.0,<1.7.0"
-  - DJANGO="Django>=1.7.0,<1.8.0"
   - DJANGO="Django>=1.8.0,<1.9.0"
 
 # command to install dependencies


### PR DESCRIPTION
I couldn't find any projects we're using this package in - I'm removing the unsupported versions of django.